### PR TITLE
fix: use UrlHelper when setting consolePollUrl to support the PathPrefix

### DIFF
--- a/src/Hangfire.Console/Dashboard/DynamicJsDispatcher.cs
+++ b/src/Hangfire.Console/Dashboard/DynamicJsDispatcher.cs
@@ -21,10 +21,12 @@ internal class DynamicJsDispatcher : IDashboardDispatcher
     {
         var builder = new StringBuilder();
 
+        var urlHelper = new UrlHelper(context);
+
         builder.Append("(function (hangfire) {")
             .Append("hangfire.config = hangfire.config || {};")
             .AppendFormat("hangfire.config.consolePollInterval = {0};", _options.PollInterval)
-            .AppendFormat("hangfire.config.consolePollUrl = '{0}/console/';", context.Request.PathBase)
+            .AppendFormat("hangfire.config.consolePollUrl = '{0}';", urlHelper.To("/console/"))
             .Append("})(window.Hangfire = window.Hangfire || {});")
             .AppendLine();
 


### PR DESCRIPTION
Fixes the console polling when using hangfire with the PathPrefix used to work with load balancers. 